### PR TITLE
Add unlimited has_many field to administrate

### DIFF
--- a/app/dashboards/food_dashboard.rb
+++ b/app/dashboards/food_dashboard.rb
@@ -14,7 +14,7 @@ class FoodDashboard < Administrate::BaseDashboard
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
     child: Field::Boolean,
-    people: Field::HasMany,
+    people: UnlimitedHasManyField,
     food_choices_count: Field::Number,
   }.freeze
 

--- a/app/dashboards/person_dashboard.rb
+++ b/app/dashboards/person_dashboard.rb
@@ -10,7 +10,7 @@ class PersonDashboard < Administrate::BaseDashboard
   ATTRIBUTE_TYPES = {
     food_choices: Field::HasMany,
     rsvp_code: Field::BelongsTo,
-    foods: Field::HasMany,
+    foods: UnlimitedHasManyField,
     id: Field::Number,
     full_name: Field::String,
     attending_ceremony: Field::Boolean,

--- a/app/dashboards/rsvp_code_dashboard.rb
+++ b/app/dashboards/rsvp_code_dashboard.rb
@@ -8,7 +8,7 @@ class RsvpCodeDashboard < Administrate::BaseDashboard
   # which determines how the attribute is displayed
   # on pages throughout the dashboard.
   ATTRIBUTE_TYPES = {
-    people: Field::HasMany,
+    people: UnlimitedHasManyField,
     id: Field::Number,
     secret: Field::String.with_options(searchable: false),
     ceremony: Field::Boolean,

--- a/app/fields/unlimited_has_many_field.rb
+++ b/app/fields/unlimited_has_many_field.rb
@@ -1,0 +1,7 @@
+require "administrate/field/base"
+
+class UnlimitedHasManyField < Administrate::Field::HasMany
+  def resources
+    data
+  end
+end

--- a/app/views/fields/unlimited_has_many_field/_form.html.erb
+++ b/app/views/fields/unlimited_has_many_field/_form.html.erb
@@ -1,0 +1,8 @@
+<div class="field-unit__label">
+  <%= f.label field.attribute_key, field.attribute %>
+</div>
+<div class="field-unit__field">
+  <%= f.select(field.attribute_key, nil, {}, multiple: true) do %>
+    <%= options_for_select(field.associated_resource_options, field.selected_options) %>
+  <% end %>
+</div>

--- a/app/views/fields/unlimited_has_many_field/_index.html.erb
+++ b/app/views/fields/unlimited_has_many_field/_index.html.erb
@@ -1,0 +1,1 @@
+<%= pluralize(field.data.size, field.attribute.to_s.humanize.downcase) %>

--- a/app/views/fields/unlimited_has_many_field/_show.html.erb
+++ b/app/views/fields/unlimited_has_many_field/_show.html.erb
@@ -1,0 +1,9 @@
+<% if field.resources.any? %>
+  <%= render(
+    "collection",
+    collection_presenter: field.associated_collection,
+    resources: field.resources
+  ) %>
+<% else %>
+  <%= t("administrate.fields.has_many.none", default: "–") %>
+<% end %>


### PR DESCRIPTION
This inherits from Administrate::Field::HasMany but removes the limit option, which has a default of 5.